### PR TITLE
fix: JwtUtil.java, JwtInterceptor.java 파일 수정을 통해 보안성 강화

### DIFF
--- a/NEW_Eatory-backend/pom.xml
+++ b/NEW_Eatory-backend/pom.xml
@@ -100,18 +100,18 @@
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt-api</artifactId>
-			<version>0.12.6</version>
+			<version>0.11.5</version>
 		</dependency>
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt-impl</artifactId>
-			<version>0.12.6</version>
+			<version>0.11.5</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt-jackson</artifactId>
-			<version>0.12.6</version>
+			<version>0.11.5</version>
 			<scope>runtime</scope>
 		</dependency>
 

--- a/NEW_Eatory-backend/src/main/java/com/eatory/mvc/jwt/JwtUtil.java
+++ b/NEW_Eatory-backend/src/main/java/com/eatory/mvc/jwt/JwtUtil.java
@@ -1,11 +1,13 @@
 package com.eatory.mvc.jwt;
 
 import java.nio.charset.StandardCharsets;
+import java.security.Key;
 import java.util.Date;
 import java.util.function.Function;
 
 import javax.crypto.SecretKey;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import io.jsonwebtoken.Claims;
@@ -13,11 +15,13 @@ import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
 
 @Component
 public class JwtUtil {
-	private String key = "SSAFY_NonMajor_JavaTrack_SecretKey";
-	private SecretKey secretKey = Keys.hmacShaKeyFor(key.getBytes(StandardCharsets.UTF_8));
+	@Value("${jwt.secret}")
+	private String key;
+	private Key secretKey;
 	
 	  // Access Token 유효 기간 (1시간)
     private final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60;
@@ -25,6 +29,10 @@ public class JwtUtil {
     // Refresh Token 유효 기간 (7일)
     private final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;
 	
+    @PostConstruct
+    public void init() {
+        this.secretKey = Keys.hmacShaKeyFor(key.getBytes(StandardCharsets.UTF_8));
+    }
 	
 	
     /**
@@ -78,8 +86,8 @@ public class JwtUtil {
      */
     private Claims extractAllClaims(String token) {
         return Jwts.parserBuilder()
-                .setSigningKey(getSigningKey())
-                .setAllowedClockSkewSeconds(1)
+                .setSigningKey(secretKey)
+                .setAllowedClockSkewSeconds(60) //서버와 클라 간 시간 차이 허용 시간 증가 
                 .build()
                 .parseClaimsJws(token)
                 .getBody();

--- a/NEW_Eatory-backend/src/main/resources/application.properties
+++ b/NEW_Eatory-backend/src/main/resources/application.properties
@@ -15,3 +15,5 @@ mybatis.configuration.map-underscore-to-camel-case=true
 spring.servlet.multipart.max-file-size=20MB
 spring.servlet.multipart.max-request-size=50MB
 
+# JwtUtil - JWT secretKey 따로 관리
+jwt.secret=SSAFY_NonMajor_JavaTrack_SecretKey


### PR DESCRIPTION
### 연관 작업
#3 

### 작업 개요
JwtUtil.java 및 JwtInterceptor.java의 개선을 통해 보안성을 강화하고 코드의 명확성과 가독성을 높였습니다. 주요 변경 사항은 하드코딩된 Key 제거, 토큰 검증 로직 개선, 예외 처리 로직 보완 등입니다.

---

### 주요 변경 사항
#### **JwtUtil.java**
1. **Secret Key 관리**
   - 하드코딩된 Key를 제거하고, `application.properties` 파일에서 Secret Key를 관리하도록 수정.
   - Secret Key는 JWT 토큰 서명 생성 및 검증에 사용되어 토큰의 무결성을 보장합니다.

2. **getSigningKey 메서드 제거**
   - Secret Key를 반환하는 메서드를 삭제하고 직접 참조로 수정하여 코드 일관성을 유지.

3. **시간 차이 허용 설정**
   - 서버와 클라이언트 간의 시간 차이를 허용하기 위해 `setAllowedClockSkewSeconds` 값을 기존 1초에서 60초로 증가.
   - 클라이언트와 서버의 시간 차이로 인해 발생할 수 있는 토큰 유효성 검증 오류를 방지.

#### **JwtInterceptor.java**
1. **Authorization 헤더 처리**
   - Authorization 헤더가 없거나, 잘못된 형식일 경우를 명확히 처리.
   - "Bearer " 형식을 확인하고, substring(7)을 통해 토큰만 추출.
       - "Bearer "는 HTTP Authorization 헤더에서 사용되는 인증 토큰 유형을 나타내는 표준 포맷입니다. Bearer는 "이 토큰을 소지한 사람(Bearer)이 인증 권한을 가진다"는 뜻입니다. 보통 **JWT (JSON Web Token)**이나 OAuth 2.0 인증에서 액세스 토큰을 전달할 때 사용됩니다.

2. **토큰 검증**
   - `JwtUtil.validateToken` 메서드를 활용하여 JWT 토큰의 유효성을 검증.
   - 토큰 내 클레임에서 이메일을 추출하여 `request.setAttribute`를 통해 요청 속성에 저장.

3. **예외 처리**
   - 모든 예외에 대한 적절한 응답 메시지를 반환.
   - `e.getMessage()`를 사용하여 오류 원인을 클라이언트에 전달.

---

### 테스트
1. **Secret Key 관리**
   - 하드코딩된 Key 제거 및 `application.properties`를 통한 Secret Key 관리 정상 동작 확인.
2. **토큰 검증 로직**
   - 잘못된 토큰, 만료된 토큰, 변조된 토큰에 대한 유효성 검증 테스트 완료.
3. **시간 차이 허용**
   - 서버와 클라이언트 간 시간 차이에 따른 토큰 유효성 검증 테스트 완료.
4. **예외 처리**
   - Authorization 헤더 누락, 잘못된 형식, 토큰 검증 실패에 대한 적절한 예외 메시지 반환 확인.

---

### 리뷰 요청
- **Secret Key 관리 방식**이 적절한지 확인 부탁드립니다.
- Authorization 헤더 및 토큰 검증 로직 개선 사항에 대한 의견 부탁드립니다.
- 예외 처리 방식 및 메시지 전달의 개선점이 있는지 검토 부탁드립니다.

---

이번 PR은 JWT 인증 및 보안 체계를 강화하고, 클라이언트와의 인증 프로세스를 명확히 개선하기 위한 작업입니다. 리뷰 부탁드립니다!
