### PR TITLE
feat: 로그아웃 기능 구현

### DIFF
--- a/NEW_Eatory-backend/src/main/java/com/eatory/mvc/controller/UserController.java
+++ b/NEW_Eatory-backend/src/main/java/com/eatory/mvc/controller/UserController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.eatory.mvc.jwt.JwtUtil;
@@ -79,6 +80,25 @@ public class UserController {
 			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
 		}
 	}
+	
+	//로그아웃 API
+	@PostMapping("/logout")
+	public ResponseEntity<String> logout(@RequestParam String email) {
+		try {
+			// Refresh Token 삭제
+			boolean isDeleted = userService.logoutUser(email);
+			
+			if(isDeleted) {
+				return ResponseEntity.status(HttpStatus.OK).body("Logout 성공!");
+			} else {
+				return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Logout 실패!");
+			}
+		} catch (Exception e) {
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("로그아웃 중 에러가 발생했습니다.");
+		}
+	}
+	
+	
 	
 	@PostMapping("/refresh")
 	public ResponseEntity<Map<String, String>> refresh(@RequestBody Map<String, String> request){

--- a/NEW_Eatory-backend/src/main/java/com/eatory/mvc/model/dao/UserDao.java
+++ b/NEW_Eatory-backend/src/main/java/com/eatory/mvc/model/dao/UserDao.java
@@ -25,4 +25,6 @@ public interface UserDao {
 
 	public void saveRefreshToken(String email, String refreshToken, Date expiresAt);
 
+	public void deleteRefreshTokenByEmail(String email);
+
 }

--- a/NEW_Eatory-backend/src/main/java/com/eatory/mvc/model/service/UserService.java
+++ b/NEW_Eatory-backend/src/main/java/com/eatory/mvc/model/service/UserService.java
@@ -30,6 +30,8 @@ public interface UserService {
 	//Refresh 토큰 검증 및 새로운 Access Token 발급 
 	public String refreshAccessToken(String email, String refreshToken);
 
+	public boolean logoutUser(String email);
+
 
 	
 

--- a/NEW_Eatory-backend/src/main/java/com/eatory/mvc/model/service/UserServiceImpl.java
+++ b/NEW_Eatory-backend/src/main/java/com/eatory/mvc/model/service/UserServiceImpl.java
@@ -112,6 +112,18 @@ public class UserServiceImpl implements UserService{
 	}
 
 
+	@Override
+	@Transactional
+	public boolean logoutUser(String email) {
+		try {
+			userDao.deleteRefreshTokenByEmail(email);
+			return true;
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+
 	
 	
 	

--- a/NEW_Eatory-backend/src/main/resources/eatory_db_SQLfile.sql
+++ b/NEW_Eatory-backend/src/main/resources/eatory_db_SQLfile.sql
@@ -125,6 +125,10 @@ CREATE TABLE refresh_tokens (
     token_value VARCHAR(500) NOT NULL UNIQUE, -- Refresh Token 값
     issued_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, -- 토큰 발급 시간
     expires_at TIMESTAMP, -- 토큰 만료 시간
+    CONSTRAINT `fk_refresh_user_email`
+        FOREIGN KEY (`user_email`)
+        REFERENCES `users` (`email`)
+        ON DELETE CASCADE, -- 사용자가 삭제되면 Refresh Token도 삭제
     UNIQUE(user_email) -- 동일 이메일에 대한 중복 방지
 );
 

--- a/NEW_Eatory-backend/src/main/resources/mappers/userMapper.xml
+++ b/NEW_Eatory-backend/src/main/resources/mappers/userMapper.xml
@@ -6,69 +6,78 @@
 
 
 	<!-- 회원 프로필 조회 -->
-	<select id="findUserProfile" parameterType="long" resultType="UserProfile">
-		SELECT 
-			u.username AS username,
-			u.profile_image AS profileImage,
-			u.height AS height,
-			u.weight AS weight,
-			a.allergy_name AS allergyName,
-			(SELECT COUNT(*) FROM Post p WHERE p.user_id = #{userId}) AS postCount,
-			(SELECT COUNT(*) FROM Follow f WHERE f.followee_id = #{userId}) AS followerCount,
-			(SELECT COUNT(*) FROM Follow f WHERE f.follower_id = #{userId}) AS followeeCount
+	<select id="findUserProfile" parameterType="long"
+		resultType="UserProfile">
+		SELECT
+		u.username AS username,
+		u.profile_image AS profileImage,
+		u.height AS height,
+		u.weight AS weight,
+		a.allergy_name AS allergyName,
+		(SELECT COUNT(*) FROM Post p WHERE p.user_id = #{userId}) AS postCount,
+		(SELECT COUNT(*) FROM Follow f WHERE f.followee_id = #{userId}) AS
+		followerCount,
+		(SELECT COUNT(*) FROM Follow f WHERE f.follower_id = #{userId}) AS
+		followeeCount
 		FROM User u
-		LEFT JOIN UserAllergy ua ON ua.user_id = u.user_id
+		LEFT JOIN UserAllergy ua ON ua.user_id =
+		u.user_id
 		WHERE u.user_id = #{userId}
 	</select>
-	
+
 	<!-- 회원목록 가져오기 -->
 	<select id="selectAll" resultType="User">
 		SELECT *
 		FROM user
 	</select>
-	
+
 	<!-- 회원가입(회원등록) -->
-	<insert id="insertUser" parameterType="User" useGeneratedKeys="true" keyProperty="userId" >
-		INSERT INTO user (username, password, email, height, weight, gender, birth_date, profile_image, phone_number)
-		VALUES (#{username}, #{password},#{email},#{height},#{weight},#{gender},#{birth_date},#{profile_image},#{phone_number})
+	<insert id="insertUser" parameterType="User"
+		useGeneratedKeys="true" keyProperty="userId">
+		INSERT INTO user
+		(username, password, email, height, weight, gender, birth_date,
+		profile_image, phone_number)
+		VALUES (#{username},
+		#{password},#{email},#{height},#{weight},#{gender},#{birth_date},#{profile_image},#{phone_number})
 	</insert>
-	
-	
-	<!-- 로그인 (Refresh Token 적용 전)
-	<select id="selectOne" parameterType="Map" resultType="User">
-		SELECT email, username
+
+
+	<!-- 로그인 (Refresh Token 적용 전) <select id="selectOne" parameterType="Map" 
+		resultType="User"> SELECT email, username FROM user WHERE email = #{email} 
+		AND password = #{password} </select> -->
+
+	<!-- 로그인 (사용자 조회) -->
+	<select id="findUserByEmailAndPassword" parameterType="map"
+		resultType="User">
+		SELECT user_id, email, username, password
 		FROM user
 		WHERE email = #{email} AND password = #{password}
-	</select> -->
-	
-	<!-- 로그인 (사용자 조회) -->
-    <select id="findUserByEmailAndPassword" parameterType="map" resultType="User">
-        SELECT user_id, email, username, password
-        FROM user
-        WHERE email = #{email} AND password = #{password}
-    </select>
+	</select>
 
-    <!-- Refresh Token 저장 -->
-    <insert id="saveRefreshToken">
-        INSERT INTO refresh_tokens (user_email, token_value, expires_at)
-        VALUES (#{email}, #{refreshToken}, #{expiresAt})
-        ON DUPLICATE KEY UPDATE
-            token_value = #{refreshToken},
-            expires_at = #{expiresAt};
-    </insert>
 
-    <!-- Refresh Token 조회 -->
-    <select id="getRefreshTokenByEmail" parameterType="string" resultType="string">
-        SELECT token_value
-        FROM refresh_tokens
-        WHERE user_email = #{email};
-    </select>
 
-    <!-- Refresh Token 삭제 -->
-    <delete id="deleteRefreshTokenByEmail" parameterType="string">
-        DELETE FROM refresh_tokens
-        WHERE user_email = #{email};
-    </delete>
-	
-	
+	<!-- Refresh Token 저장 -->
+	<insert id="saveRefreshToken">
+		INSERT INTO refresh_tokens (user_email, token_value, expires_at)
+		VALUES (#{email}, #{refreshToken}, #{expiresAt})
+		ON DUPLICATE KEY UPDATE
+		token_value = #{refreshToken},
+		expires_at = #{expiresAt};
+	</insert>
+
+	<!-- Refresh Token 조회 -->
+	<select id="getRefreshTokenByEmail" parameterType="string"
+		resultType="string">
+		SELECT token_value
+		FROM refresh_tokens
+		WHERE user_email = #{email};
+	</select>
+
+	<!-- Refresh Token 삭제 (로그아웃)-->
+	<delete id="deleteRefreshTokenByEmail" parameterType="string">
+		DELETE FROM refresh_tokens
+		WHERE user_email = #{email};
+	</delete>
+
+
 </mapper>


### PR DESCRIPTION
### 연관 작업
#3 

### 작업 개요
로그아웃 API를 구현하여 클라이언트가 로그아웃 요청 시, Refresh Token을 삭제하는 기능을 추가했습니다. 이를 통해 보안을 강화하고, 중복 토큰 사용을 방지할 수 있습니다.

---

### 주요 변경 사항
#### 1. 로그아웃 API 구현
- **UserController**
  - `POST /api-user/logout` 엔드포인트 생성.
  - 클라이언트로부터 이메일을 받아 서비스 계층 호출.
  
- **UserService**
  - `logoutUser` 메서드 추가.
  - `UserDao` 호출하여 Refresh Token 삭제 로직 처리.

- **MyBatis Mapper**
  - `deleteRefreshTokenByEmail` 쿼리 작성.
  - `refresh_tokens` 테이블에서 이메일 기반 Refresh Token 삭제.

---

### 테스트
- **Refresh Token 삭제 확인**
  - 이메일에 해당하는 Refresh Token이 성공적으로 삭제되는지 테스트 완료.
- **존재하지 않는 이메일 요청 처리**
  - 존재하지 않는 이메일로 요청 시 실패 메시지 반환 확인.
- **서버 오류 상황 테스트**
  - 예외 발생 시 500 응답 메시지 반환 확인.

---

### 기대 효과
- 클라이언트 로그아웃 시 Refresh Token을 안전하게 삭제하여 보안 강화.
- 중복 토큰 사용 방지 가능.

---

### 추가 작업
1. **Refresh Token 만료 시 자동 삭제 로직 검토**
   - Refresh Token의 만료 시점에 따른 자동 삭제 로직 필요 여부 검토.
2. **Access Token 블랙리스트 관리 검토**
   - Access Token 무효화를 위한 블랙리스트 관리 로직 도입 검토 가능.

---

### 리뷰 요청
- 로그아웃 로직의 예외 처리와 응답 메시지가 적절한지 검토 부탁드립니다.
- 서비스 계층에서의 로직 분리 여부 및 추가 개선 사항에 대한 의견 부탁드립니다.

---

본 PR은 로그아웃 기능 구현을 통해 보안을 강화하고, 클라이언트 로그아웃 요청을 처리할 수 있도록 하기 위한 작업입니다. 리뷰 부탁드립니다!
