### PR TITLE
fix: 로그아웃 API에서 @RequestParam → @RequestBody로 변경

### DIFF
--- a/NEW_Eatory-backend/src/main/java/com/eatory/mvc/controller/UserController.java
+++ b/NEW_Eatory-backend/src/main/java/com/eatory/mvc/controller/UserController.java
@@ -83,7 +83,13 @@ public class UserController {
 	
 	//로그아웃 API
 	@PostMapping("/logout")
-	public ResponseEntity<String> logout(@RequestParam String email) {
+	public ResponseEntity<String> logout(@RequestBody Map<String, String> body) {
+		
+		String email = body.get("email");
+		if (email == null || email.isEmpty()) {
+	        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Email is required");
+	    }
+		
 		try {
 			// Refresh Token 삭제
 			boolean isDeleted = userService.logoutUser(email);


### PR DESCRIPTION
### 연관 작업
#3 
#16 

### 작업 개요
로그아웃 API에서 email을 수신하는 방식을 `@RequestParam`에서 `@RequestBody`로 변경하였습니다. 이로 인해 클라이언트가 JSON 형식으로 데이터를 전송할 수 있도록 API를 개선하였습니다.
(목적: 프론트에서 로그아웃 버튼을 누를 때 'Home' 화면으로 새로고침 없이 바로 이동하기 위함)

---

### 주요 변경 사항
1. **로그아웃 API 수정**
   - `@RequestParam`으로 email을 받던 방식을 `@RequestBody`로 변경.
   - 요청 데이터가 JSON 형식으로 전달될 수 있도록 수정.
   
2. **클라이언트 요청 방식 개선**
   - 프론트엔드에서 `axios.post`로 요청 시, email을 JSON 본문으로 전송하도록 변경.

---

### 테스트
- JSON 형식으로 email을 전송했을 때 API가 정상적으로 동작하는지 확인.
- 요청 본문이 없거나 잘못된 형식으로 전송된 경우 적절한 오류 메시지 반환 확인.

---

### 기대 효과
- 클라이언트와 서버 간 요청/응답 구조 일관성 유지.
- 잘못된 요청 방식으로 인한 오류 방지.
- JSON 데이터를 활용한 확장성 있는 API 설계 가능.

---

### 리뷰 요청
- 요청 데이터 구조 변경(@RequestParam → @RequestBody)이 적절한지 검토 부탁드립니다.
- 오류 처리 방식 및 클라이언트와의 데이터 통신 방식에 대한 개선점이 있다면 의견 부탁드립니다.

---

이번 PR은 로그아웃 API의 요청 방식 변경을 통해 클라이언트와의 데이터 통신을 개선하고, 잘못된 요청으로 인한 오류를 방지하기 위한 작업입니다. 리뷰 부탁드립니다!
