### PR TITLE
fix: refreshToken 토큰 검증 후 새 access Token을 발급할 때, user_id를 반환하지 않는 문제 해결

### DIFF
--- a/NEW_Eatory-backend/src/main/resources/mappers/userMapper.xml
+++ b/NEW_Eatory-backend/src/main/resources/mappers/userMapper.xml
@@ -7,6 +7,7 @@
 	<select id="findUserProfile" parameterType="long"
 		resultMap="UserProfileResultMap">
 		SELECT 
+			u.user_id AS id,
 			u.username AS username,
 			u.profile_image AS profileImage,
 			u.height AS height,
@@ -24,6 +25,7 @@
 	</select>
 	
 	<resultMap id="UserProfileResultMap" type="com.eatory.mvc.model.dto.UserProfile">
+    	<result property="id" column="id" />
 	    <result property="username" column="username" />
 	    <result property="profileImage" column="profileImage" />
 	    <result property="height" column="height" />


### PR DESCRIPTION
### 연관 작업
#3 

---
### 작업 개요
Refresh Token을 검증한 후 새로운 Access Token을 발급하는 과정에서 `user_id`가 반환되지 않는 문제를 해결하였습니다.

---

### 주요 변경 사항
1. **Refresh Token 검증 로직 수정**
   - Refresh Token 검증 후 `user_id`를 포함하여 응답하도록 수정.
   - 새로운 Access Token 발급 시, 기존 사용자 정보를 유지하면서 추가 데이터 반환.

2. **UserService 수정**
   - Refresh Token 검증 메서드에서 `user_id`를 포함한 사용자 데이터 반환 로직 추가.

3. **UserDao 및 Mapper 수정**
   - Refresh Token이 유효한 경우, 데이터베이스에서 `user_id`를 조회하여 반환.

4. **테스트**
   - Refresh Token 검증 후 새로운 Access Token과 함께 `user_id`가 올바르게 반환되는지 테스트 완료.

---

### 테스트
1. **유효한 Refresh Token 사용**
   - Refresh Token을 통해 새로운 Access Token을 발급받고 `user_id`가 포함된 응답 확인.

2. **만료된 Refresh Token 사용**
   - 만료된 토큰으로 요청 시 적절한 에러 응답 반환 확인.

3. **유효하지 않은 Refresh Token 사용**
   - 유효하지 않은 토큰으로 요청 시 401 Unauthorized 응답 확인.

---

### 기대 효과
- 클라이언트가 새로운 Access Token을 발급받은 후 `user_id`를 활용하여 추가적인 API 요청을 수행할 수 있음.
- Refresh Token을 통한 인증 프로세스의 일관성 강화.

---

### 리뷰 요청
1. Refresh Token 검증 로직이 적절한지 검토 부탁드립니다.
2. 응답 데이터에 추가적인 필드가 필요한지 의견 요청드립니다.
3. Refresh Token 검증 실패 시 예외 처리 메시지가 적절한지 확인 부탁드립니다.

---

이번 PR은 인증 로직의 완성도를 높이고, 클라이언트-서버 간 데이터 교환의 일관성을 유지하기 위한 작업입니다. 피드백 부탁드립니다! 😊
