### PR TITLE
DietRecord 테이블 및 데이터베이스 확장 구현

### DIFF
--- a/NEW_Eatory-backend/src/main/java/com/eatory/mvc/controller/DietRecordController.java
+++ b/NEW_Eatory-backend/src/main/java/com/eatory/mvc/controller/DietRecordController.java
@@ -29,53 +29,41 @@ public class DietRecordController {
     // 특정 사용자 ID에 속한 기록 조회
     @GetMapping("/user/{userId}")
     @Operation(summary = "기록 조회", description = "특정 사용자에 속한 모든 기록을 조회합니다.")
-    public ResponseEntity<List<DietRecord>> getRecordsByUserId(@PathVariable("userId") Long userId) {
-        List<DietRecord> dietRecords = dietRecordService.getRecordsByUserId(userId);
-        if (dietRecords.isEmpty()) {
-            return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
-        }
-        return ResponseEntity.ok(dietRecords);
+    public ResponseEntity<List<DietRecord>> getRecordsByUserId(@PathVariable Long userId) {
+        List<DietRecord> records = dietRecordService.getRecordsByUserId(userId);
+        return records.isEmpty() ? ResponseEntity.noContent().build() : ResponseEntity.ok(records);
     }
 
     // 특정 ID의 기록 조회
     @GetMapping("/{recordId}")
     @Operation(summary = "특정 기록 조회", description = "특정 ID의 기록을 조회합니다.")
-    public ResponseEntity<DietRecord> getRecordById(@PathVariable("recordId") Long recordId) {
-        DietRecord dietRecord = dietRecordService.getRecordById(recordId);
-        if (dietRecord == null) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
-        }
-        return ResponseEntity.ok(dietRecord);
+    public ResponseEntity<DietRecord> getRecordById(@PathVariable Long recordId) {
+        DietRecord record = dietRecordService.getRecordById(recordId);
+        return record == null ? ResponseEntity.notFound().build() : ResponseEntity.ok(record);
     }
 
     // 새로운 기록 추가
     @PostMapping("/")
     @Operation(summary = "기록 추가", description = "새로운 기록을 추가합니다.")
     public ResponseEntity<DietRecord> addDietRecord(@RequestBody DietRecord dietRecord) {
-        DietRecord createdDietRecord = dietRecordService.addDietRecord(dietRecord);
-        return new ResponseEntity<>(createdDietRecord, HttpStatus.CREATED);
+        DietRecord createdRecord = dietRecordService.addDietRecord(dietRecord);
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdRecord);
     }
 
     // 기록 수정
     @PutMapping("/{recordId}")
     @Operation(summary = "기록 수정", description = "특정 ID의 기록을 수정합니다.")
-    public ResponseEntity<DietRecord> updateDietRecord(@PathVariable("recordId") Long recordId, @RequestBody DietRecord dietRecord) {
+    public ResponseEntity<DietRecord> updateDietRecord(@PathVariable Long recordId, @RequestBody DietRecord dietRecord) {
         dietRecord.setRecordId(recordId);
-        DietRecord updatedDietRecord = dietRecordService.updateDietRecord(dietRecord);
-        if (updatedDietRecord == null) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
-        }
-        return ResponseEntity.ok(updatedDietRecord);
+        DietRecord updatedRecord = dietRecordService.updateDietRecord(dietRecord);
+        return updatedRecord == null ? ResponseEntity.notFound().build() : ResponseEntity.ok(updatedRecord);
     }
 
     // 기록 삭제
     @DeleteMapping("/{recordId}")
     @Operation(summary = "기록 삭제", description = "특정 ID의 기록을 삭제합니다.")
-    public ResponseEntity<Void> deleteDietRecord(@PathVariable("recordId") Long recordId) {
+    public ResponseEntity<Void> deleteDietRecord(@PathVariable Long recordId) {
         boolean isDeleted = dietRecordService.deleteDietRecord(recordId);
-        if (isDeleted) {
-            return ResponseEntity.status(HttpStatus.OK).build();
-        }
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        return isDeleted ? ResponseEntity.ok().build() : ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
 }

--- a/NEW_Eatory-backend/src/main/java/com/eatory/mvc/model/dto/DietRecord.java
+++ b/NEW_Eatory-backend/src/main/java/com/eatory/mvc/model/dto/DietRecord.java
@@ -1,48 +1,62 @@
 package com.eatory.mvc.model.dto;
 
 import java.util.Date;
+import java.util.List;
 
 public class DietRecord {
     private Long recordId;
     private Long userId;
-    private Integer calendarId;
     private Date recordDate;
-    private String mealType;
-    private String notes;
-	public Long getRecordId() {
-		return recordId;
-	}
-	public void setRecordId(Long recordId) {
-		this.recordId = recordId;
-	}
-	public Long getUserId() {
-		return userId;
-	}
-	public void setUserId(Long userId) {
-		this.userId = userId;
-	}
-	public Integer getCalendarId() {
-		return calendarId;
-	}
-	public void setCalendarId(Integer calendarId) {
-		this.calendarId = calendarId;
-	}
-	public Date getRecordDate() {
-		return recordDate;
-	}
-	public void setRecordDate(Date recordDate) {
-		this.recordDate = recordDate;
-	}
-	public String getMealType() {
-		return mealType;
-	}
-	public void setMealType(String mealType) {
-		this.mealType = mealType;
-	}
-	public String getNotes() {
-		return notes;
-	}
-	public void setNotes(String notes) {
-		this.notes = notes;
-	}
+    private String mealType; // 아침, 점심, 저녁, 간식
+    private List<String> menus; // JSON 문자열 대신 List<String>으로 메뉴를 관리
+    private String notes; // 간단한 메모
+
+    // Getter와 Setter
+    public Long getRecordId() {
+        return recordId;
+    }
+
+    public void setRecordId(Long recordId) {
+        this.recordId = recordId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public Date getRecordDate() {
+        return recordDate;
+    }
+
+    public void setRecordDate(Date recordDate) {
+        this.recordDate = recordDate;
+    }
+
+    public String getMealType() {
+        return mealType;
+    }
+
+    public void setMealType(String mealType) {
+        this.mealType = mealType;
+    }
+
+    public List<String> getMenus() {
+        return menus;
+    }
+
+    public void setMenus(List<String> menus) {
+        this.menus = menus;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
 }

--- a/NEW_Eatory-backend/src/main/resources/eatory_db_SQLfile.sql
+++ b/NEW_Eatory-backend/src/main/resources/eatory_db_SQLfile.sql
@@ -132,7 +132,30 @@ CREATE TABLE refresh_tokens (
     UNIQUE(user_email) -- 동일 이메일에 대한 중복 방지
 );
 
+# DietRecord 테이블 생성
+CREATE TABLE DietRecord (
+    record_id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT NOT NULL, -- User와 연결
+    record_date DATE NOT NULL, -- 기록 날짜
+    meal_type ENUM('아침', '점심', '저녁', '간식') NOT NULL, -- 식사 종류
+    menus JSON NOT NULL, -- 식사 메뉴 (JSON 형식)
+    notes VARCHAR(500), -- 간단한 메모
+    FOREIGN KEY (user_id) REFERENCES User(user_id) ON DELETE CASCADE -- User 삭제 시 기록도 삭제
+);
 
+# DietRecord 더미 데이터 삽입
+INSERT INTO DietRecord (user_id, record_date, meal_type, menus, notes)
+VALUES
+(1, '2023-11-20', '아침', '["토스트", "커피"]', '상쾌한 아침!'),
+(1, '2023-11-20', '점심', '["샐러드", "치킨"]', '건강한 점심'),
+(1, '2023-11-20', '저녁', '["스테이크", "와인"]', '특별한 저녁'),
+(2, '2023-11-21', '아침', '["요거트", "바나나"]', '바쁜 아침'),
+(2, '2023-11-21', '점심', '["파스타", "콜라"]', '맛있는 점심'),
+(3, '2023-11-22', '저녁', '["피자", "맥주"]', '친구들과 저녁'),
+(4, '2023-11-23', '간식', '["초콜릿", "우유"]', '달콤한 간식'),
+(5, '2023-11-24', '점심', '["볶음밥", "김치"]', '한식 점심'),
+(6, '2023-11-25', '아침', '["팬케이크", "주스"]', '느긋한 주말 아침'),
+(7, '2023-11-26', '저녁', '["탕수육", "짜장면"]', '중국 요리 저녁');
 
 
 

--- a/NEW_Eatory-backend/src/main/resources/mappers/dietRecordMapper.xml
+++ b/NEW_Eatory-backend/src/main/resources/mappers/dietRecordMapper.xml
@@ -4,31 +4,45 @@
   "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.eatory.mvc.model.dao.DietRecordDao">
 
-    <!-- User ID로 기록 조회 -->
     <select id="findByUserId" parameterType="long" resultType="DietRecord">
-        SELECT * FROM DietRecord WHERE user_id = #{userId};
+        SELECT 
+            record_id AS recordId,
+            user_id AS userId,
+            record_date AS recordDate,
+            meal_type AS mealType,
+            notes,
+            menus
+        FROM DietRecord
+        WHERE user_id = #{userId};
     </select>
 
-    <!-- Record ID로 특정 기록 조회 -->
     <select id="findById" parameterType="long" resultType="DietRecord">
-        SELECT * FROM DietRecord WHERE record_id = #{recordId};
+        SELECT 
+            record_id AS recordId,
+            user_id AS userId,
+            record_date AS recordDate,
+            meal_type AS mealType,
+            notes,
+            menus
+        FROM DietRecord
+        WHERE record_id = #{recordId};
     </select>
 
-    <!-- 기록 데이터 삽입 -->
     <insert id="insert" parameterType="DietRecord" keyProperty="recordId" useGeneratedKeys="true">
-        INSERT INTO DietRecord (user_id, calendar_id, record_date, meal_type, notes)
-        VALUES (#{userId}, #{calendarId}, #{recordDate}, #{mealType}, #{notes});
+        INSERT INTO DietRecord (user_id, record_date, meal_type, notes, menus)
+        VALUES (#{userId}, #{recordDate}, #{mealType}, #{notes}, CAST(#{menus} AS JSON));
     </insert>
 
-    <!-- 기록 데이터 업데이트 -->
     <update id="update" parameterType="DietRecord">
         UPDATE DietRecord
-        SET user_id = #{userId}, calendar_id = #{calendarId}, record_date = #{recordDate}, 
-            meal_type = #{mealType}, notes = #{notes}
+        SET 
+            record_date = #{recordDate},
+            meal_type = #{mealType},
+            notes = #{notes},
+            menus = CAST(#{menus} AS JSON)
         WHERE record_id = #{recordId};
     </update>
 
-    <!-- 기록 데이터 삭제 -->
     <delete id="delete" parameterType="long">
         DELETE FROM DietRecord WHERE record_id = #{recordId};
     </delete>


### PR DESCRIPTION
## 🛠️ 주요 변경 사항
1. **DietRecord 테이블 추가**
   - 사용자 식단 기록 관리 테이블 생성.
   - 메뉴와 메모를 포함한 기록 관리 가능.
   - JSON 형식으로 메뉴 저장.

2. **더미 데이터 삽입**
   - 다양한 사용자의 식사 기록과 메뉴 예시 추가.

3. **외래 키 설정**
   - 사용자가 삭제되면 기록도 자동으로 삭제되도록 설정(`CASCADE`).

---

## 📌 변경 파일
1. `eatory_db` SQL 스크립트
   - DietRecord 테이블 생성 SQL 추가
   - 더미 데이터 삽입 SQL 추가

---

## 🔍 테스트
- [x] DietRecord 테이블 생성 후 데이터 삽입 테스트 완료.
- [x] JSON 필드(`menus`) 삽입 및 조회 정상 작동 확인.
- [x] 외래 키 제약 조건 검증 완료.

---

## 📂 참고 이슈
- 관련 이슈: #23 