### PR TITLE
fix: json 형태의 응답에서 loginUser의 이름을 name에서 username으로 변경함

### DIFF
--- a/NEW_Eatory-backend/src/main/java/com/eatory/mvc/model/service/UserServiceImpl.java
+++ b/NEW_Eatory-backend/src/main/java/com/eatory/mvc/model/service/UserServiceImpl.java
@@ -106,7 +106,7 @@ public class UserServiceImpl implements UserService{
 			response.put("refresh-token", refreshToken);
 			response.put("user", Map.of(
 			            "id", user.getUserId(),
-			            "name", user.getUsername(),
+			            "username", user.getUsername(),
 			            "email", user.getEmail(),
 			            "profileImage", userProfile.getProfileImage(),
 			            "postCount", userProfile.getPostCount(),


### PR DESCRIPTION
문제상황: 
- 로그인 응답을 serviceImpl에서 response.put "name"으로 함
- 프론트에서 로그인 시 loginUser.name 으로 반환 가능
- refreshToken 갱신시 loginUser 는 username으로 들어옴(mapper의 이름 설정)

받아오는 이름의 차이를 username으로 통일함