### PR TITLE
fix: 이제 모든 data는 id와 userId로 혼동되지 않고 모두 'userId'로만 저장될 것입니다.

### DIFF
--- a/NEW_Eatory-backend/src/main/java/com/eatory/mvc/model/dto/UserProfile.java
+++ b/NEW_Eatory-backend/src/main/java/com/eatory/mvc/model/dto/UserProfile.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class UserProfile {
-	private Long id;
+	private Long userId;
 	private String username;
 	private String email;
 	private String profileImage;
@@ -14,11 +14,12 @@ public class UserProfile {
 	private List<String> allergies = new ArrayList<>();
 	private int height;
 	private int weight;
-	public Long getId() {
-		return id;
+	
+	public Long getUserId() {
+		return userId;
 	}
-	public void setId(Long id) {
-		this.id = id;
+	public void setUserId(Long userId) {
+		this.userId = userId;
 	}
 	public String getUsername() {
 		return username;

--- a/NEW_Eatory-backend/src/main/java/com/eatory/mvc/model/service/UserServiceImpl.java
+++ b/NEW_Eatory-backend/src/main/java/com/eatory/mvc/model/service/UserServiceImpl.java
@@ -88,6 +88,7 @@ public class UserServiceImpl implements UserService {
 			UserProfile userProfile = userDao.findUserProfile(user.getUserId());
 			if (userProfile == null) {
 				userProfile = new UserProfile(); // null 안전 처리
+				userProfile.setUserId(user.getUserId());
 				userProfile.setUsername(user.getUsername());
 				userProfile.setEmail(user.getEmail());
 				userProfile.setProfileImage("");
@@ -104,7 +105,7 @@ public class UserServiceImpl implements UserService {
 			response.put("access-token", accessToken);
 			response.put("refresh-token", refreshToken);
 			response.put("user",
-					Map.of("id", user.getUserId(), 
+					Map.of("userId", user.getUserId(), 
 							"username", user.getUsername(), 
 							"email", user.getEmail(),
 							"profileImage", userProfile.getProfileImage(), 

--- a/NEW_Eatory-backend/src/main/resources/mappers/userMapper.xml
+++ b/NEW_Eatory-backend/src/main/resources/mappers/userMapper.xml
@@ -7,7 +7,7 @@
 	<select id="findUserProfile" parameterType="long"
 		resultMap="UserProfileResultMap">
 		SELECT 
-			u.user_id AS id,
+			u.user_id AS userId,
 			u.username AS username,
 			u.email AS email,
 			u.profile_image AS profileImage,


### PR DESCRIPTION

... 이게 오류의 원인이 되었다면 진심으로 죄송합니다...

### 작업 개요
세션에 `id`로 저장되던 데이터를 `userId`로 통일하여, 모든 데이터 처리에서 `userId`만 사용하도록 변경하였습니다. 이로 인해 `id`와 `userId` 간의 혼동을 해소하고 코드 일관성을 강화하였습니다.

---

### 주요 변경 사항
1. **세션 저장 키 변경**
   - 기존에 `id`로 저장되던 값을 `userId`로 변경.
   - 모든 세션 관련 로직이 `userId`를 참조하도록 수정.

2. **ervice, Mapper 수정**
   - 요청 및 응답에서 `id` 필드를 제거하고 `userId`로 통일.
   - Service 및 Mapper 계층에서 데이터 처리 시 `userId`를 사용하도록 수정.

3. **DTO 및 응답 데이터 변경**
   - DTO와 API 응답 데이터에서 `id` 대신 `userId`로 필드 이름 통일.
   - 클라이언트에서 혼동 없이 데이터를 처리할 수 있도록 데이터 구조 수정.

---

### 테스트
1. **로그인 및 세션 상태 확인**
   - 로그인 후 세션에 `userId`가 올바르게 저장되는지 확인.
   - 세션 데이터를 복원(`restoreSession`)할 때 `userId`로 상태가 복구되는지 확인.

2. **API 요청 및 응답 테스트**
   - 모든 API에서 `userId`로 데이터를 송수신하는지 확인.
   - 데이터베이스 쿼리 및 매핑 로직에서 `userId`가 올바르게 동작하는지 검증.

3. **UI 연동 테스트**
   - 클라이언트에서 `userId`로 데이터를 처리하고, 기존 `id` 필드에 대한 의존성이 제거되었는지 확인.

---

### 기대 효과
- `id`와 `userId` 간의 혼동을 해소하여 코드의 가독성과 유지보수성 개선.
- 세션 및 API 데이터 처리의 일관성 확보.
- 클라이언트와 서버 간 데이터 교환 오류 방지.

---

### 리뷰 요청
1. 모든 데이터에서 `id` 대신 `userId`로 통일한 접근 방식이 적절한지 검토 부탁드립니다.
2. 클라이언트-서버 간 데이터 호환성 확인 요청.
3. 추가적인 코드 개선 사항에 대한 의견 요청.

---

이번 PR은 데이터 필드의 명명 규칙을 통일하여 코드 일관성을 강화하고, 혼동을 방지하기 위한 작업입니다. 피드백 부탁드립니다! 😊
